### PR TITLE
Add qualifier to stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,34 +37,35 @@ Usage:
   kaleido-go [flags]
 
 Flags:
-  -a, --accounts stringArray     Account addresses - 1 per worker needed for geth signing
-  -x, --args stringArray         String arguments to pass to contract method (auto-converted to type)
-  -C, --call                     Call the contract and return a value, rather than sending a txn
-  -i, --chainid int              Chain ID for EIP155 signing (networkid queried if omitted)
-  -c, --contract string          Pre-deployed contract address. Will be deployed if not specified
-  -n, --contractname string      The name of the contract to call, for Solidity files with multiple contracts
-  -d, --debug int                0=error, 1=info, 2=debug (default 1)
-  -E, --estimategas              Estimate the gas for the contract call, rather than sending a txn
-  -e, --extsign                  Sign externally with generated private keys + accounts
-  -f, --file string              Solidity smart contract source. Deployed if --contract not supplied
-  -F, --flush-period int         Flush period for statsd metrics (ms) (default 1000)
-  -g, --gas int                  Gas limit on the transaction (default 1000000)
-  -G, --gasprice int             Gas price
-  -h, --help                     help for kaleido-go
-  -k, --keys string              JSON file to create/update with an array of private keys for extsign
-  -l, --loops int                Loops to perform in each worker before exiting (0=infinite) (default 1)
-  -m, --method string            Method name in the contract to invoke
-  -M, --metrics string           statsd server to submit metrics to
-  -N, --nonce int                Nonce (transaction number) for the next transaction (default -1)
-  -P, --privateFor stringArray   Private for (see EEA Client Spec V1)
-  -p, --privateFrom string       Private from (see EEA Client Spec V1)
-  -R, --rpc-timeout int          Timeout in seconds for an individual RCP call (default 30)
-  -S, --seconds-max int          Time in seconds before timing out waiting for a txn receipt (default 20)
-  -s, --seconds-min int          Time in seconds to wait before checking for a txn receipt (default 11)
-  -T, --telegraf                 Telegraf/InfluxDB stats naming (default is Graphite)
-  -t, --transactions int         Count of transactions submit on each worker loop (default 1)
-  -u, --url string               JSON/RPC URL for Ethereum node: https://user:pass@xyz-rpc.kaleido.io
-  -w, --workers int              Number of workers to run (default 1)
+  -a, --accounts stringArray       Account addresses - 1 per worker needed for geth signing
+  -x, --args stringArray           String arguments to pass to contract method (auto-converted to type)
+  -C, --call                       Call the contract and return a value, rather than sending a txn
+  -i, --chainid int                Chain ID for EIP155 signing (networkid queried if omitted)
+  -c, --contract string            Pre-deployed contract address. Will be deployed if not specified
+  -n, --contractname string        The name of the contract to call, for Solidity files with multiple contracts
+  -d, --debug int                  0=error, 1=info, 2=debug (default 1)
+  -E, --estimategas                Estimate the gas for the contract call, rather than sending a txn
+  -e, --extsign                    Sign externally with generated private keys + accounts
+  -f, --file string                Solidity smart contract source. Deployed if --contract not supplied
+  -F, --flush-period int           Flush period for statsd metrics (ms) (default 1000)
+  -g, --gas int                    Gas limit on the transaction (default 1000000)
+  -G, --gasprice int               Gas price
+  -h, --help                       help for kaleido-go
+  -k, --keys string                JSON file to create/update with an array of private keys for extsign
+  -l, --loops int                  Loops to perform in each worker before exiting (0=infinite) (default 1)
+  -m, --method string              Method name in the contract to invoke
+  -M, --metrics string             statsd server to submit metrics to
+  -q, --metrics-qualifier string   Additional metrics qualifier
+  -N, --nonce int                  Nonce (transaction number) for the next transaction (default -1)
+  -P, --privateFor stringArray     Private for (see EEA Client Spec V1)
+  -p, --privateFrom string         Private from (see EEA Client Spec V1)
+  -R, --rpc-timeout int            Timeout in seconds for an individual RCP call (default 30)
+  -S, --seconds-max int            Time in seconds before timing out waiting for a txn receipt (default 20)
+  -s, --seconds-min int            Time in seconds to wait before checking for a txn receipt (default 11)
+  -T, --telegraf                   Telegraf/InfluxDB stats naming (default is Graphite)
+  -t, --transactions int           Count of transactions submit on each worker loop (default 1)
+  -u, --url string                 JSON/RPC URL for Ethereum node: https://user:pass@xyz-rpc.kaleido.io
+  -w, --workers int                Number of workers to run (default 1)
 ```
 
 ## Build

--- a/cmd/kaleido-go.go
+++ b/cmd/kaleido-go.go
@@ -65,6 +65,7 @@ func init() {
 	cmd.Flags().StringVarP(&exerciser.StatsdServer, "metrics", "M", "", "statsd server to submit metrics to")
 	cmd.Flags().IntVarP(&exerciser.TxnsPerLoop, "transactions", "t", 1, "Count of transactions submit on each worker loop")
 	cmd.Flags().BoolVarP(&exerciser.StatsdTelegraf, "telegraf", "T", false, "Telegraf/InfluxDB stats naming (default is Graphite)")
+	cmd.Flags().StringVarP(&exerciser.StatsdQualifier, "metrics-qualifier", "q", "", "Additional metrics qualifier")
 	cmd.Flags().StringVarP(&exerciser.URL, "url", "u", "", "JSON/RPC URL for Ethereum node: https://user:pass@xyz-rpc.kaleido.io")
 	cmd.Flags().IntVarP(&exerciser.Workers, "workers", "w", 1, "Number of workers to run")
 	cmd.MarkFlagRequired("url")

--- a/pkg/kldexerciser/kldexerciser.go
+++ b/pkg/kldexerciser/kldexerciser.go
@@ -50,6 +50,7 @@ type Exerciser struct {
 	StatsdServer      string
 	StatsdFlushPeriod int64
 	StatsdTelegraf    bool
+	StatsdQualifier   string
 	RPCTimeout        int
 	PrivateFrom       string
 	PrivateFor        []string


### PR DESCRIPTION
Allows a qualifier to be passed from the command line to all stats emitted by the exerciser.
- For statsd/carbon formatted stats it is prefixed to the stat, such as `prefix.server....`
- For telegraf/influxdb formatted stats it is added as a `qual` tag on the entry